### PR TITLE
Corrected namespace for the SessionIndex element to samlp

### DIFF
--- a/openam/openam-federation/openam-federation-library/src/main/csharpsource/Fedlet/Fedlet/source/Saml2/LogoutRequest.cs
+++ b/openam/openam-federation/openam-federation-library/src/main/csharpsource/Fedlet/Fedlet/source/Saml2/LogoutRequest.cs
@@ -168,7 +168,7 @@ namespace Sun.Identity.Saml2
                 rawXml.Append(" <saml:NameID xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"");
                 rawXml.Append("  Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:transient\"");
                 rawXml.Append("  NameQualifier=\"" + identityProvider.EntityId + "\">" + subjectNameId + "</saml:NameID> ");
-                rawXml.Append(" <saml:SessionIndex xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" + sessionIndex + "</saml:SessionIndex>");
+                rawXml.Append(" <saml:SessionIndex xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\">" + sessionIndex + "</saml:SessionIndex>");
                 rawXml.Append(" <saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" + serviceProvider.EntityId + "</saml:Issuer>");
                 rawXml.Append("</samlp:LogoutRequest>");
 


### PR DESCRIPTION
Corrected namespace for the SessionIndex element to samlp as per http://docs.oasis-open.org/security/saml/v2.0/saml-schema-protocol-2.0.xsd (line 267).
