### PR TITLE
Avoid escaping OAuth2 scope values in XUI Login page

### DIFF
--- a/openam-ui/openam-ui-ria/src/main/resources/templates/user/AuthorizeTemplate.html
+++ b/openam-ui/openam-ui-ria/src/main/resources/templates/user/AuthorizeTemplate.html
@@ -33,7 +33,7 @@
                 <div class="panel panel-info">
                     <div class="panel-heading am-panel-heading-hover" data-toggle="collapse" aria-expanded="false"
                          data-target="#oauth2Scope{{@index}}" aria-controls="oauth2Scope{{@index}}">
-                        {{this.name}}
+                        {{{this.name}}}
                         <div class="pull-right"><i class="fa fa-angle-down"></i></div>
                     </div>
 
@@ -43,7 +43,7 @@
                                 <small>{{this.values}}</small><br/>
                             {{else}}
                                 {{#each this.values}}
-                                    <small><strong>{{@key}}:</strong> {{this}}</small><br/>
+                                    <small><strong>{{@key}}:</strong> {{{this}}}</small><br/>
                                 {{/each}}
                             {{/if}}
                         </div>


### PR DESCRIPTION
Currently the scopes are displayed like this:

![screenshot from 2015-11-06 14 51 47](https://cloud.githubusercontent.com/assets/8210299/10993610/0519986a-8496-11e5-80db-38dfba0b40b6.png)

Instead of:

![screenshot from 2015-11-06 14 45 50](https://cloud.githubusercontent.com/assets/8210299/10993613/0c365b6a-8496-11e5-837d-d3fd07fb9ef5.png)

Fix provided by using "triple-stash", {{{ as per http://handlebarsjs.com/ HTML Escaping
